### PR TITLE
Change ClusterRole to view

### DIFF
--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -8,5 +8,5 @@ subjects:
   namespace: lemur
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: view
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
As we discussed at KubeCon, the operator service account shouldn't need cluster-admin permissions since it is only viewing cluster resources.  Changed the role to the built-in "view" cluster role.