### PR TITLE
Allow insecure connection to SSL enabled InfluxDB server

### DIFF
--- a/lemurctl/cli/cli.go
+++ b/lemurctl/cli/cli.go
@@ -46,15 +46,20 @@ func Run() {
 			EnvVar: "INFLUXDB_SERVER",
 		},
 		cli.BoolFlag{
-			Name:   "debug,d",
-			Usage:  "enable debug mode",
-			EnvVar: "DEBUG",
+			Name:   "insecure,k",
+			Usage:  "allow connections to SSL enabled InfluxDB server without certs",
+			EnvVar: "INSECURE_CONNECTION",
 		},
 		cli.StringFlag{
 			Name:   "log-level,l",
 			Value:  "info",
 			Usage:  "specify log level (debug, info, warn, error, fatal, panic)",
 			EnvVar: "LOG_LEVEL",
+		},
+		cli.BoolFlag{
+			Name:   "debug,d",
+			Usage:  "enable debug mode",
+			EnvVar: "DEBUG",
 		},
 	}
 

--- a/lemurctl/pkg/influx/db.go
+++ b/lemurctl/pkg/influx/db.go
@@ -107,6 +107,7 @@ func (q *DBQuery) build() string {
 func NewDBInstance(c *cli.Context) (*DBInstance, error) {
 	influxClient, err := client.NewHTTPClient(client.HTTPConfig{
 		Addr: "http://" + c.GlobalString("influxdb"),
+		InsecureSkipVerify: c.GlobalBool("insecure"),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We can now expose the InfluxDB service through istio ingress gateway, where we redirect http request to https. This pull request allow the client to skip https certificate verifications.