### PR TITLE
Update lemur code base to be in sync with turbonomic 7.21.0

### DIFF
--- a/deploy/crds/charts_v1alpha1_lemur_cr.yaml
+++ b/deploy/crds/charts_v1alpha1_lemur_cr.yaml
@@ -17,6 +17,8 @@ spec:
         serve_from_sub_path: true
       users:
         default_theme: light
+    service:
+      portName: http-service
 
   # Probes
   kubeturbo:
@@ -42,6 +44,9 @@ spec:
 
   # Lemur service configurations and resource limits
   api:
+    image:
+      repository: lemurnomic
+      tag: 7.21.0
     resources:
       limits:
         memory: 512Mi
@@ -58,12 +63,15 @@ spec:
       limits:
         memory: 1Gi
   influxdb:
-    service:
-      type: LoadBalancer
+    persistence:
+      size: 10Gi
     resources:
       limits:
         memory: 256Mi
   ml-datastore:
+    image:
+      repository: lemurnomic
+      tag: 7.21.0
     resources:
       limits:
         memory: 512Mi
@@ -125,8 +133,8 @@ spec:
   # DO NOT CHANGE THE FOLLOWING SECTION UNLESS YOU ARE SURE
   # =======================================================================
   global:
-    repository: lemurnomic
-    tag: 0.1.0
+    repository: turbonomic
+    tag: 7.21.0
     pullPolicy: Always
     ingress:
       domain: "*"
@@ -203,7 +211,7 @@ spec:
           prefix: /grafana
       route:
       - destination:
-          host: grafana
+          host: grafana.lemur.svc.cluster.local
           port:
             number: 3000
     - match:
@@ -232,7 +240,16 @@ spec:
           host: tracing.istio-system.svc.cluster.local
           port:
             number: 80
-  
+    - match:
+      - uri:
+          prefix: /influxdb/query
+      rewrite:
+        uri: /query
+      route:
+      - destination:
+          host: influxdb.lemur.svc.cluster.local
+          port:
+            number: 8086
   platform:
     enabled: true
   control:
@@ -241,9 +258,11 @@ spec:
     enabled: true
   prometheus:
     enabled: true
-  awscost:
-    enabled: false
-  azurecost:
-    enabled: false
+    nodeExporter:
+      hostNetwork: false
+  loki:
+    enabled: true
+  promtail:
+    enabled: true
   # =======================================================================
 

--- a/deploy/destination_rule_istio.yaml
+++ b/deploy/destination_rule_istio.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+ name: "istio-kiali"
+ namespace: "istio-system"
+spec:
+ host: "kiali.istio-system.svc.cluster.local"
+ trafficPolicy:
+   tls:
+     mode: DISABLE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+ name: "istio-tracing"
+ namespace: "istio-system"
+spec:
+ host: "tracing.istio-system.svc.cluster.local"
+ trafficPolicy:
+   tls:
+     mode: DISABLE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: t8c-operator
           # Replace this with the built image name
-          image: lemurnomic/t8c-operator:0.1.0
+          image: lemurnomic/t8c-operator:7.21.0
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Change grafana service port name to http-service
Use turbonomic 7.21.0 images for all component images, except for api, ml-datastore
Add destination rule to disable TLS for Kiali and Jaeger in MTLS enabled istio environment