### PR TITLE
Update kubeturbo image tag from latest to 7.21.1

### DIFF
--- a/deploy/crds/charts_v1alpha1_lemur_cr.yaml
+++ b/deploy/crds/charts_v1alpha1_lemur_cr.yaml
@@ -30,7 +30,7 @@ spec:
       opsManagerPassword: administrator
     image:
       repository: turbonomic/kubeturbo
-      tag: latest
+      tag: 7.21.1
     serverMeta:
       version: 7.21
       turboServer: https://t8c-istio-ingressgateway.lemur


### PR DESCRIPTION
Update `kubeturbo` image tag from latest to `7.21.1` to make sure `kubeturbo` is stable.